### PR TITLE
feat: Add admin microservices

### DIFF
--- a/apps/admin/admin.controller.ts
+++ b/apps/admin/admin.controller.ts
@@ -1,0 +1,14 @@
+import { Controller } from '@nestjs/common';
+import { EventPattern, Payload } from '@nestjs/microservices';
+import { AdminService } from './admin.service';
+import { CreateAdminDto } from '@libs/dto';
+
+@Controller()
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @EventPattern('admin.create')
+  handleUserCreate(@Payload() data: CreateAdminDto) {
+    this.adminService.create(data);
+  }
+}

--- a/apps/admin/admin.module.ts
+++ b/apps/admin/admin.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+imports: [ConfigModule.forRoot({ isGlobal: true })],
+controllers: [AdminController],
+providers: [AdminService],
+})
+export class AdminModule {}

--- a/apps/admin/admin.service.ts
+++ b/apps/admin/admin.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CreateAdminDto } from '@libs/dto';
+
+@Injectable()
+export class AdminService {
+  private readonly logger = new Logger(AdminService.name);
+
+  create(dto: CreateAdminDto) {
+    // Simulate user creation logic
+    this.logger.log(`✅ Admin created: ${JSON.stringify(dto)}`);
+  }
+}

--- a/apps/admin/main.ts
+++ b/apps/admin/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import { AdminModule } from './admin.module';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { createKafkaConfig } from '@libs/kafka.config';
+
+async function bootstrap() {
+  const kafkaOptions = createKafkaConfig('admin-service', 'admin-consumer-group');
+
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
+    AdminModule,
+    {
+      transport: Transport.KAFKA,
+      options: kafkaOptions,
+    },
+  );
+
+  await app.listen();
+  console.log('🚀 Admin Microservice is running and listening for Kafka events...');
+}
+bootstrap();

--- a/libs/dto/index.ts
+++ b/libs/dto/index.ts
@@ -2,4 +2,8 @@ export interface CreateUserDto {
     email: string;
     password: string;
   }
-  
+
+  export interface CreateAdminDto {
+    email: string;
+    password: string;
+  }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "start:email": "ts-node -r tsconfig-paths/register apps/email/main.ts",
     "dev:docker": "docker-compose up --build",
     "down:docker": "docker-compose down -v",
-    "logs:docker": "docker-compose logs -f --tail=100"
+    "logs:docker": "docker-compose logs -f --tail=100",
+    "start:user":  "ts-node -r tsconfig-paths/register apps/user/main.ts",
+    "start:admin": "ts-node -r tsconfig-paths/register apps/admin/main.ts",
+    "start:ambassador": "nest start --watch apps/ambassador",
+    "start:checkout": "nest start --watch apps/checkout"
   },
   "dependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
This commit adds the admin module, controller, service, and main file to the project. The admin module includes the necessary imports and configurations, while the controller handles the 'admin.create' event and calls the admin service to create a new admin. The admin service contains the logic for creating an admin and logs the successful creation. The main file sets up the admin microservice using Kafka as the transport.