### PR TITLE
feat: Add admin and checkout deployment and service files

### DIFF
--- a/k8s/admin/deployment.yaml
+++ b/k8s/admin/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: admin
+  template:
+    metadata:
+      labels:
+        app: admin
+    spec:
+      containers:
+        - name: admin
+          image: jhaytech/admin-service:latest
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: app-config
+            - secretRef:
+                name: jwt-secret

--- a/k8s/admin/service.yaml
+++ b/k8s/admin/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin-service
+spec:
+  selector:
+    app: admin
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP

--- a/k8s/checkout/deployment.yaml
+++ b/k8s/checkout/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: admin
+  template:
+    metadata:
+      labels:
+        app: admin
+    spec:
+      containers:
+        - name: admin
+          image: jhaytech/checkout-service:latest
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: app-config
+            - secretRef:
+                name: jwt-secret

--- a/k8s/checkout/service.yaml
+++ b/k8s/checkout/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkout-service
+spec:
+  selector:
+    app: checkout
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
This pull request introduces Kubernetes configurations for deploying and exposing two services: `admin-service` and `checkout-service`. The changes include the creation of Deployment and Service YAML files for both services, ensuring proper container configuration, environment variable management, and network exposure.

### Kubernetes Configurations for `admin-service`:

* [`k8s/admin/deployment.yaml`](diffhunk://#diff-29a7198a569382a37628aaedf999a28c4ffe3200942f0249ce650d2c4327e9ccR1-R24): Added a Deployment configuration for `admin-service`, specifying one replica, container image `jhaytech/admin-service:latest`, environment variables from a ConfigMap (`app-config`) and a Secret (`jwt-secret`), and exposing port 3000.
* [`k8s/admin/service.yaml`](diffhunk://#diff-34301cafcb5ecc1229b5503cdb0518fdbbc98ef2d499aea19adb99e6054d942fR1-R12): Added a Service configuration for `admin-service`, exposing it as a ClusterIP service on port 3000.

### Kubernetes Configurations for `checkout-service`:

* [`k8s/checkout/deployment.yaml`](diffhunk://#diff-1035047946a50efbda3db0068b914eb0fe67c68ffda91874d6d9c441ede9e708R1-R24): Added a Deployment configuration for `checkout-service`, specifying one replica, container image `jhaytech/checkout-service:latest`, environment variables from a ConfigMap (`app-config`) and a Secret (`jwt-secret`), and exposing port 3000.
* [`k8s/checkout/service.yaml`](diffhunk://#diff-cdae373e2f6a57c1f774abc24d780f2898849e361d20b76884e774fb986b1117R1-R12): Added a Service configuration for `checkout-service`, exposing it as a ClusterIP service on port 3000.