### PR TITLE
feat: Add Kafka module and KafkaProducerService

### DIFF
--- a/libs/kafka.module.ts
+++ b/libs/kafka.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { KafkaProducerService } from './kafka.producer';
+
+@Module({
+  providers: [KafkaProducerService],
+  exports: [KafkaProducerService],
+})
+export class KafkaModule {}

--- a/libs/kafka.producer.ts
+++ b/libs/kafka.producer.ts
@@ -1,0 +1,35 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { Kafka, Producer } from 'kafkajs';
+
+@Injectable()
+export class KafkaProducerService implements OnModuleInit, OnModuleDestroy {
+  private kafka: Kafka;
+  private producer: Producer;
+
+  constructor() {
+    this.kafka = new Kafka({
+      brokers: [process.env.KAFKA_BROKER || 'localhost:9092'],
+      clientId: 'monolith-app',
+    });
+
+    this.producer = this.kafka.producer();
+  }
+
+  async onModuleInit() {
+    await this.producer.connect();
+    console.log('✅ Kafka Producer connected');
+  }
+
+  async onModuleDestroy() {
+    await this.producer.disconnect();
+  }
+
+  async emit(topic: string, payload: Record<string, any>) {
+    await this.producer.send({
+      topic,
+      messages: [{ value: JSON.stringify(payload) }],
+    });
+
+    console.log(`📤 Kafka event emitted on topic "${topic}"`);
+  }
+}


### PR DESCRIPTION
This commit adds a new Kafka module and the KafkaProducerService class to the project. The Kafka module is responsible for providing the KafkaProducerService, which is used to connect to a Kafka broker and emit events to specified topics. This addition enables the application to integrate with Kafka and send messages to other services